### PR TITLE
Create browser-only .js file evaluating application/wisp scripts.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,3 +62,9 @@ node-engine:
 browser-engine:
 	mkdir -p ./engine/
 	cat ./src/engine/browser.wisp | $(WISP) > ./engine/browser.js
+
+browser-embed: core browser-engine bundle-browser-engine
+bundle-browser-engine:
+	$(BROWSERIFY) --debug \
+                --exports require \
+                --entry ./engine/browser.js > ./browser-embed.js

--- a/src/engine/browser.wisp
+++ b/src/engine/browser.wisp
@@ -1,7 +1,7 @@
 (ns wisp.engine.browser
   (:require [wisp.runtime :refer [str]]
             [wisp.sequence :refer [rest]]
-            [wisp.reader :refer [read-from-string]]
+            [wisp.reader :refer [read* read-from-string]]
             [wisp.compiler :refer [compile*]]))
 
 (defn evaluate


### PR DESCRIPTION
I did the changes you suggested in #50, and found that I have to add read\* to functions required by src/engine/browser.wisp to make it work.

This allows me to do something like this:

``` html
<!DOCTYPE html>
<html>
  <head>
    <meta charset="utf-8">
    <title>Wisp</title>
    <script src="scripts/wisp.js"></script>
    <script type="application/wisp">
      (print "Wisp code run on the client in a script tag!")
    </script>
    <script type="application/wisp" src="scripts/test.wisp"></script>
  </head>
  <body>
  </body>
</html>
```

`scripts/wisp.js` being the `browser-embed.js` created by this new Makefile, and

`scripts/test.wisp` being file with contents:

``` clojure
(print "Wisp code run on the client from a file!")
```

this does

```
Wisp code run on the client in a script tag!
Wisp code run on the client from a file!
```

in my console.
