### PR TITLE
remove duplicate upper-case function

### DIFF
--- a/src/string.wisp
+++ b/src/string.wisp
@@ -26,11 +26,6 @@
   [string]
   (.toUpperCase string))
 
-(defn upper-case
-  "Converts string to all upper-case."
-  [string]
-  (.toUpperCase string))
-
 (defn lower-case
   "Converts string to all lower-case."
   [string]


### PR DESCRIPTION
There was a duplicate definition of the "upper-case" function, so this just removes it.