### PR TITLE
Make running code in the browser possible again.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.js
 interactivate
 src/drafts/*
+node_modules/*

--- a/Readme.md
+++ b/Readme.md
@@ -1,6 +1,8 @@
 # WISP
 
 [![Build Status](https://secure.travis-ci.org/Gozala/wisp.png)](http://travis-ci.org/Gozala/wisp)
+[![NPM version](https://badge.fury.io/js/wisp.svg)](http://badge.fury.io/js/wisp)
+[![Dependency Status](https://david-dm.org/gozala/wisp.svg)](https://david-dm.org/gozala/wisp)
 [![Gitter chat](https://badges.gitter.im/Gozala/wisp.png)](https://gitter.im/Gozala/wisp)
 
 _wisp_ is a [homoiconic][homoiconicity] JavaScript dialect with [Clojure][]

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "test": "make all && make test"
   },
   "dependencies": {
-    "escodegen": "git://github.com/Constellation/escodegen.git#2ec9bce21b223579fabd9f8cbad7d073068b22c3",
+    "escodegen": "git://github.com/Constellation/escodegen.git#41fbbe5058849b5e082542c5cfce76c2d67792e6",
     "base64-encode": "~1.0.1",
     "commander": ">=2.2.0"
   }

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "test": "make all && make test"
   },
   "dependencies": {
-    "escodegen": "git://github.com/Constellation/escodegen.git#master",
+    "escodegen": "git://github.com/Constellation/escodegen.git#2ec9bce21b223579fabd9f8cbad7d073068b22c3",
     "base64-encode": "~1.0.1",
     "commander": ">=2.2.0"
   }


### PR DESCRIPTION
Hello @Gozala :-)
I noticed that `engine/browser.wisp` looks for the non-existent `compile*` function, preventing any code to be compiled in a browser environment. I've patched it with the code from `engines/node.wisp`, and it seems to work.
Thanks for providing a JVM-free alternative to ClojureScript! :-)