### PR TITLE
fixing string replace

### DIFF
--- a/src/string.wisp
+++ b/src/string.wisp
@@ -74,10 +74,10 @@
    See also replace-first."
   [string match replacement]
   (cond (string? match)
-        (replace string (RegExp. pattern-escape match) "g" replacement)
+        (.replace string (RegExp. (pattern-escape match) "g") replacement)
 
         (re-pattern? match)
-        (.replace s (RegExp. (.-source match) "g") replacement)
+        (.replace string (RegExp. (.-source match) "g") replacement)
 
         :else
         (throw (str "Invalid match arg: " match))))

--- a/test/string.wisp
+++ b/test/string.wisp
@@ -1,6 +1,6 @@
 (ns wisp.test.string
   (:require [wisp.test.util :refer [is thrown?]]
-            [wisp.src.string :refer [join split]]
+            [wisp.src.string :refer [join split replace]]
             [wisp.src.sequence :refer [list]]
             [wisp.src.runtime :refer [str =]]))
 
@@ -41,3 +41,22 @@
 
 (is (= ["Some" "words" "to" "split"]
        (split "Some words to split" " ")))
+
+; replace tests
+; basic test
+(is (= "wtring" (replace "string" "s" "w")))
+; testing 'g' flag for replace
+(is (= "hewwo" (replace "string" "l" "w")))
+; basic regex
+(is (= "tenten" (replace "10ten" #"[0-9]+" "ten")))
+; g flag on basic regex
+(is (= "tententen" (replace "19ten10" #"[0-9]+" "ten")))
+
+
+
+
+
+
+
+
+

--- a/test/string.wisp
+++ b/test/string.wisp
@@ -46,7 +46,7 @@
 ; basic test
 (is (= "wtring" (replace "string" "s" "w")))
 ; testing 'g' flag for replace
-(is (= "hewwo" (replace "string" "l" "w")))
+(is (= "hewwo" (replace "hello" "l" "w")))
 ; basic regex
 (is (= "tenten" (replace "10ten" #"[0-9]+" "ten")))
 ; g flag on basic regex


### PR DESCRIPTION
I tried using string replace on a fresh install of wisp today. 
The code seems to be broken, unless I'm misunderstanding something here - why is there a variable 's' in this function?

I fixed it to the best of my knowledge, and the playground compiles it to

```js
var replace = exports.replace = function replace(string, match, replacement) {
        return isString(match) ? string.replace(new RegExp(patternEscape(match), 'g'), replacement) : isRePattern(match) ? string.replace(new RegExp(match.source, 'g'), replacement) : 'else' ? (function () {
            throw '' + 'Invalid match arg: ' + match;
        })() : void 0;
    };
``` 

which looks right to me. 
I had to actually manually fix this in the string.js file, so if you could update the npm package as well that would be awesome.