### PR TITLE
fixes typos readme, false? butlast and capitalize bugfixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.js
 interactivate
 src/drafts/*
+node_modules/

--- a/Readme.md
+++ b/Readme.md
@@ -260,7 +260,7 @@ Variable definitions also happen through special forms:
 
 In _wisp_ variables can be set to new values via the `set!` special form.
 
-Note that in functional programing binding changes are a bad practice (avoiding these will improve the quality and testability of your code), but there are always cases where this is required for JavaScript interoperability:
+Note that in functional programming binding changes are a bad practice (avoiding these will improve the quality and testability of your code), but there are always cases where this is required for JavaScript interoperability:
 
 ```clojure
 (set! a 1) ; => a = 1
@@ -713,7 +713,7 @@ not recognized by _wisp_ and will therefore be ignored.
 
 ### Types and Protocols
 
-In wisp protocols can be defined same as in Clojure(Script),
+In wisp protocols can be defined much in the same fashion as one would do in Clojure(Script),
 via [defprotocol](http://clojuredocs.org/clojure_core/clojure.core/defprotocol):
 
 ```clojure
@@ -743,7 +743,7 @@ extended to implement specific protocol using
   (-rest [array] (.slice array 1)))
 ```
 
-Once type / class implemnets some protocol, it's functions can be used
+Once type / class implements some protocol, it's functions can be used
 on the instances of that type / class.
 
 ```clojure

--- a/src/runtime.wisp
+++ b/src/runtime.wisp
@@ -180,7 +180,7 @@
 (defn ^boolean false?
   "Returns true if x is true"
   [x]
-  (identical? x true))
+  (identical? x false))
 
 (defn re-find
   "Returns the first regex match, if any, of s to re, using

--- a/src/sequence.wisp
+++ b/src/sequence.wisp
@@ -1,5 +1,5 @@
 (ns wisp.sequence
-  (:require [wisp.runtime :refer [nil? vector? fn? number? string? dictionary?
+  (:require [wisp.runtime :refer [subs nil? vector? fn? number? string? dictionary?
                                   key-values str dec inc merge dictionary]]))
 
 ;; Implementation of list

--- a/src/string.wisp
+++ b/src/string.wisp
@@ -34,9 +34,9 @@
 (defn ^String capitalize
   "Converts first character of the string to upper-case, all other
   characters to lower-case."
-  [string]
-  (if (< (count string) 2)
-      (upper-case string)
+  [s]
+  (if (< (count s) 2)
+      (upper-case s)
       (str (upper-case (subs s 0 1))
            (lower-case (subs s 1)))))
 


### PR DESCRIPTION
Includes fixing a few readme typos, `false?` (runtime), `butlast` (missing reference to subs) and `capitalize` (wrong variable used)