### PR TITLE
Enable Glagol support by translating slashes in identifiers to dots

### DIFF
--- a/src/backend/escodegen/writer.wisp
+++ b/src/backend/escodegen/writer.wisp
@@ -49,7 +49,8 @@
   **macros**      __macros__
   list->vector    listToVector
   set!            set
-  foo_bar         foo_bar
+  foo.bar         foo_bar
+  foo/bar         foo.bar
   number?         isNumber
   red=            redEqual
   create-server   createServer"
@@ -71,6 +72,8 @@
   (set! id (join "_" (split id "*")))
   ;; foo.bar -> foo_bar
   (set! id (join "_" (split id ".")))
+  ;; foo/bar -> foo.bar
+  (set! id (join "." (split id "/")))
   ;; list->vector ->  listToVector
   (set! id (if (identical? (subs id 0 2) "->")
              (subs (join "-to-" (split id "->")) 1)


### PR DESCRIPTION
This is a patch which allows for compatibility with [Glagol](https://github.com/egasimus/glagol), a clever little live coding framework that I've been working on for the last few months. One of its main features actually originated from this very hack; turns out that replacing slashes with dots allows `(./foo/bar baz)` to be translated to `_.foo.bar(baz)` rather than the nonsensical `_.foo/bar(baz)`. This is not only more consistent with how namespaces are currently handled in Wisp, but, in Glagol, allows you to use a path-like syntax to get the values of neighboring files (which are helpfully provided by Glagol in a `_` global object.)

I understand that this is a somewhat weird feature and not consistent with the Clojure side of things (AFAIK Clojure does not support anything like nested namespaces). Still, I consider it beneficial to contribute this to upstream, so that Glagol can support Wisp out-of-the-box without having to maintain a patched fork. (I actually tried monkeypatching the writer at runtime -- but, within the writer module, the original `var` reference to the unpatched function was preserved, so it didn't work).

I have also fixed an assumed typo in the docstring for `translate-identifier-word`.