### PR TITLE
repl:Fix slicing first character(#141)

### DIFF
--- a/src/repl.wisp
+++ b/src/repl.wisp
@@ -2,7 +2,7 @@
   (:require [repl :as repl]
             [vm :as vm]
             [wisp.runtime :refer [subs =]]
-            [wisp.sequence :refer [count list conj cons vec]]
+            [wisp.sequence :refer [count list conj cons vec last]]
             [wisp.compiler :refer [compile read-forms analyze-forms generate]]
             [wisp.ast :refer [pr-str]]
             [base64-encode :as btoa]))
@@ -42,7 +42,10 @@
     (fn evaluate [code context file callback]
       (if (not (identical? input code))
         (do
-          (set! input (subs code 1 (- (count code) 1)))
+          (set! input
+            (if (not (identical? (last code) "\n"))
+              (subs code 0 (- (count code) 1))
+              code))
           (set! output (evaluate-code input file context))
           (callback (:error output) (:value output)))
         (callback (:error output))))))


### PR DESCRIPTION
Fixed #141 .

This bug occurred in node v0.11.7 or later due to node's changing behaviour of its repl.

Until node v0.11.6, user input string passed to evaluate function always wrapped with paren.

``` javascript
> 1+1;
'(' + '1+1;' + '\n' + ')'
```

So, wisp's repl removes this automatically added parens by `(subs code 1 (- (count code) 1))` (code=user input string).

But since [this commit](https://github.com/nodejs/node/commit/9ef9a9dee54a464a46739b14e8a348bec673c5a5#diff-b13d72249263845d8e8341db0426f9d3L258) ,
only input string wrapped with curly brace would be wrapped with paren, other inputs are passed directly.
Additionaly, position of `\n` is also changed (to tail, not inside of parens).

``` javascript
> 1+1;
'1+1;' + '\n'
> { a: "b" }
'(' + '{ a: "b" }' + ')' + '\n'
```

..But wisp's repl doesn't know this, so it removes first and last character and tries to evaluate it.
This causes slicing first character (and last LF) in node v0.11.7~.

``` wisp
=> (console.log "wisp") ;; '(console.log "wisp" )\n' -> 'console.log "wisp")'
 SyntaxError: Unmatched delimiter 
```

Checking the last character of input string is equal to checking node version(`\n`:v0.11.7~ , `)`:~v0.11.6).
So this workaround does:
- if the last character is not `\n`(= `)` ), remove outermost parens(~v0.11.6)
- if the last character is `\n`, pass input directly(v0.11.7~)

(Sorry for my poor English)
