### PR TITLE
Adding UMD-friendly browserExport.wisp file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,8 +83,17 @@ browser-engine:
 	mkdir -p ./engine/
 	cat ./src/engine/browser.wisp | $(WISP) --source-uri wisp/engine/browser.wisp --no-map > ./engine/browser.js
 
+browser-export:
+	mkdir -p ./engine/
+	cat ./src/engine/browserExport.wisp | $(WISP) --source-uri wisp/engine/browserExports.wisp --no-map > ./engine/browserExport.js
+
 browser-embed: core browser-engine bundle-browser-engine
 bundle-browser-engine:
 	$(BROWSERIFY) --debug \
                   --exports require \
                   --entry ./engine/browser.js > ./browser-embed.js
+
+bundle-browser-export: core browser-engine browser-export
+	$(BROWSERIFY) --debug \
+								  -s Wisp \
+                  --entry ./engine/browserExport.js > ./browser-export.js

--- a/Readme.md
+++ b/Readme.md
@@ -1,3 +1,15 @@
+# THIS IS A FORK OF WISP
+
+## This fork is maintained by TEAM CTHULHU, [here](https://github.com/TEAM-CTHULHU/wisp)
+
+The original project is by @gozala, [here](https://github.com/Gozala/wisp).
+
+We have added a few things, like a friendly brower export so other projects can
+use this in their own REPLs. Also, we have a [Google Plus
+community](https://plus.google.com/communities/111791993160629007032).
+
+# THE ORIGINAL CONTENTS FOLLOWS...
+
 # WISP
 
 ## Project is abandoned

--- a/src/backend/escodegen/writer.wisp
+++ b/src/backend/escodegen/writer.wisp
@@ -75,6 +75,10 @@
   (set! id (if (identical? (subs id 0 2) "->")
              (subs (join "-to-" (split id "->")) 1)
              (join "-to-" (split id "->"))))
+  ;; list<-vector ->  listFromVector
+  (set! id (if (identical? (subs id 0 2) "<-")
+             (subs (join "-from-" (split id "<-")) 1)
+             (join "-from-" (split id "<-"))))
   ;; set! ->  set
   (set! id (join (split id "!")))
   (set! id (join "$" (split id "%")))

--- a/src/engine/browserExport.wisp
+++ b/src/engine/browserExport.wisp
@@ -1,0 +1,25 @@
+(ns wisp.engine.browser-export
+  (:require [wisp.engine.browser :as browser]
+            [wisp.runtime :as runtime]
+            [wisp.sequence :as sequence]
+            [wisp.reader :as reader]
+            [wisp.compiler :as compiler]
+            [wisp.string :as string]
+            [wisp.expander :as expander]
+            [wisp.analyzer :as analyzer]
+            [wisp.backend.javascript.writer :as writer]
+            [wisp.ast :as ast]
+            ))
+
+(set! module.exports {
+                      :engine {:browser browser}
+                      :runtime runtime
+                      :sequence sequence
+                      :reader reader
+                      :compiler compiler
+                      :string string
+                      :expander expander
+                      :analyzer analyzer
+                      :backend {:javascript {:writer writer}}
+                      :ast ast
+                      })

--- a/src/engine/browserExport.wisp
+++ b/src/engine/browserExport.wisp
@@ -25,7 +25,7 @@
                       :backend {
                                 :javascript {:writer jswriter}
                                 :escodegen {
-                                            :escodegen esgen
+                                            :generator esgen
                                             :writer eswriter}}
                       :ast ast
                       })

--- a/src/engine/browserExport.wisp
+++ b/src/engine/browserExport.wisp
@@ -7,7 +7,9 @@
             [wisp.string :as string]
             [wisp.expander :as expander]
             [wisp.analyzer :as analyzer]
-            [wisp.backend.javascript.writer :as writer]
+            [wisp.backend.javascript.writer :as jswriter]
+            [wisp.backend.escodegen.generator :as esgen]
+            [wisp.backend.escodegen.writer :as eswriter]
             [wisp.ast :as ast]
             ))
 
@@ -20,6 +22,10 @@
                       :string string
                       :expander expander
                       :analyzer analyzer
-                      :backend {:javascript {:writer writer}}
+                      :backend {
+                                :javascript {:writer jswriter}
+                                :escodegen {
+                                            :escodegen esgen
+                                            :writer eswriter}}
                       :ast ast
                       })

--- a/src/expander.wisp
+++ b/src/expander.wisp
@@ -2,7 +2,7 @@
   "wisp syntax and macro expander module"
   (:require [wisp.ast :refer [meta with-meta symbol? keyword?
                               quote? symbol namespace name
-                              unquote? unquote-splicing?]]
+                              unquote? unquote-splicing? gensym]]
             [wisp.sequence :refer [list? list conj partition seq
                                    empty? map vec every? concat
                                    first second third rest last
@@ -288,7 +288,10 @@
         id (with-meta name (conj (or (meta name) {}) metadata))
 
         fn (with-meta `(fn ~id ~@body) (meta &form))]
-    `(def ~id ~fn)))
+    (if doc
+      (let [FN (gensym)]
+        `(def ~id (let [~FN ~fn] (set! ~(str FN ".wispDocument") ~doc) ~FN)))
+      `(def ~id ~fn))))
 (install-macro! :defn (with-meta expand-defn {:implicit [:&form]}))
 
 


### PR DESCRIPTION
This commit adds a new engine file called browserExport.wisp that provides a UMD-friendly export for Wisp so that requirejs, etc. projects can easily access Wisp and all of its packages.  It also adds build-support for that file in the Makefile.