### PR TITLE
Put function's documentation (if any) into a "wispDocument" property on the function

### DIFF
--- a/src/expander.wisp
+++ b/src/expander.wisp
@@ -2,7 +2,7 @@
   "wisp syntax and macro expander module"
   (:require [wisp.ast :refer [meta with-meta symbol? keyword?
                               quote? symbol namespace name
-                              unquote? unquote-splicing?]]
+                              unquote? unquote-splicing? gensym]]
             [wisp.sequence :refer [list? list conj partition seq
                                    empty? map vec every? concat
                                    first second third rest last
@@ -288,7 +288,10 @@
         id (with-meta name (conj (or (meta name) {}) metadata))
 
         fn (with-meta `(fn ~id ~@body) (meta &form))]
-    `(def ~id ~fn)))
+    (if doc
+      (let [FN (gensym)]
+        `(def ~id (let [~FN ~fn] (set! ~(str FN ".wispDocument") ~doc) ~FN)))
+      `(def ~id ~fn))))
 (install-macro! :defn (with-meta expand-defn {:implicit [:&form]}))
 
 


### PR DESCRIPTION
This preserves a function's doc string by putting it into a "wispDocument" property on the function.