### PR TITLE
Set functions, ports of some Clojure macros, fixes for some bugs and discrepancies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,9 +23,8 @@ escodegen: escodegen-writer escodegen-generator
 node: core wisp node-engine repl
 browser: node core browser-engine dist/wisp.min.js
 all: browser
-test: test1
 
-test1: core node recompile
+test: core node recompile
 	$(WISP_CURRENT) ./test/test.wisp $(FLAGS)
 
 $(BUILD_DEPS):
@@ -44,8 +43,9 @@ clean:
 
 RECOMPILE = backend/escodegen/writer backend/escodegen/generator backend/javascript/writer engine/node engine/browser $(CORE)
 recompile: node browser-engine
-	$(info Recompiling with current version: $(RECOMPILE))
+	$(info Recompiling with current version:)
 	@$(foreach file,$(RECOMPILE),\
+		echo "	$(file)" && \
 		$(WISP_CURRENT) --source-uri wisp/$(file).wisp < src/$(file).wisp > $(file).js~ && \
 		mv $(file).js~ $(file).js &&) echo "...done"
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 BROWSERIFY = ./node_modules/browserify/bin/cmd.js
 MINIFY = ./node_modules/.bin/minify
-WIPS_CURRENT = node ./bin/wisp.js
+WISP_CURRENT = node ./bin/wisp.js
 FLAGS =
 INSTALL_MESSAGE = "You need to run 'npm install' to install build dependencies."
 BUILD_DEPS = $(BROWSERIFY) $(MINIFY) ./node_modules/wisp/bin/wisp.js
@@ -12,20 +12,21 @@ ifdef verbose
 endif
 
 ifdef current
-	WISP = $(WIPS_CURRENT)
+	WISP = $(WISP_CURRENT)
 else
 	WISP = ./node_modules/wisp/bin/wisp.js
 endif
 
-core: runtime sequence string ast reader compiler writer analyzer expander escodegen
+CORE = expander runtime sequence string ast reader compiler analyzer
+core: $(CORE) writer escodegen
 escodegen: escodegen-writer escodegen-generator
 node: core wisp node-engine repl
-browser: core browser-engine dist/wisp.min.js
-all: node browser
+browser: node core browser-engine dist/wisp.min.js
+all: browser
 test: test1
 
-test1: core node
-	$(WIPS_CURRENT) ./test/test.wisp $(FLAGS)
+test1: core node recompile
+	$(WISP_CURRENT) ./test/test.wisp $(FLAGS)
 
 $(BUILD_DEPS):
 	@echo $(INSTALL_MESSAGE)
@@ -40,6 +41,13 @@ clean:
 %.js: %.wisp $(WISP)
 	@mkdir -p $(dir $@)
 	$(WISP) --source-uri wisp/$(subst .js,.wisp,$@) < $< > $@
+
+RECOMPILE = backend/escodegen/writer backend/escodegen/generator backend/javascript/writer engine/node engine/browser $(CORE)
+recompile: node browser-engine
+	$(info Recompiling with current version: $(RECOMPILE))
+	@$(foreach file,$(RECOMPILE),\
+		$(WISP_CURRENT) --source-uri wisp/$(file).wisp < src/$(file).wisp > $(file).js~ && \
+		mv $(file).js~ $(file).js &&) echo "...done"
 
 ### core ###
 
@@ -69,8 +77,6 @@ writer: backend/javascript/writer.js
 
 escodegen-writer: backend/escodegen/writer.js
 
-escodegen-compiler: backend/escodegen/compiler.js
-
 escodegen-generator: backend/escodegen/generator.js
 
 ### platform engine bundles ###
@@ -79,11 +85,10 @@ node-engine: ./engine/node.js
 
 browser-engine: ./engine/browser.js
 
-dist/wisp.js: engine/browser.js $(WISP) $(BROWSERIFY) browserify.wisp core
+dist/wisp.js: engine/browser.js $(WISP) $(BROWSERIFY) browserify.wisp core recompile
 	@mkdir -p dist
-	$(WISP) browserify.wisp > dist/wisp.js
+	$(WISP_CURRENT) browserify.wisp > dist/wisp.js
 
 dist/wisp.min.js: dist/wisp.js $(MINIFY)
 	@mkdir -p dist
 	$(MINIFY) dist/wisp.js > dist/wisp.min.js
-

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "prepare": "make all",
     "test": "make test",
     "build": "make browser",
+    "clean": "make clean",
     "repl": "make recompile && node bin/wisp"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -47,7 +47,9 @@
   },
   "scripts": {
     "prepare": "make all",
-    "test": "make test"
+    "test": "make test",
+    "build": "make browser",
+    "repl": "make recompile && node bin/wisp"
   },
   "dependencies": {
     "base64-encode": "~1.0.1",

--- a/src/analyzer.wisp
+++ b/src/analyzer.wisp
@@ -377,12 +377,12 @@
 (defn analyze-let
   [env form]
   (analyze-let* env form false))
-(install-special! :let analyze-let)
+(install-special! :let* analyze-let)
 
 (defn analyze-loop
   [env form]
   (conj (analyze-let* env form true) {:op :loop}))
-(install-special! :loop analyze-loop)
+(install-special! :loop* analyze-loop)
 
 
 (defn analyze-recur
@@ -622,7 +622,7 @@
      :variadic variadic
      :methods methods
      :form form}))
-(install-special! :fn analyze-fn)
+(install-special! :fn* analyze-fn)
 
 (defn parse-references
   "Takes part of namespace definition and creates hash

--- a/src/backend/escodegen/writer.wisp
+++ b/src/backend/escodegen/writer.wisp
@@ -846,9 +846,13 @@
 
 
 (defn get-macro
-  [target property]
-  `(aget (or ~target 0)
-         ~property))
+  ([target property]
+   `(aget (or ~target 0)
+          ~property))
+  ([target property default*]
+    (if (nil? default*)
+      `(get ~target ~property)
+      `(apply get ~[target property default*]))))
 (install-macro! :get get-macro)
 
 ;; Logical operators

--- a/src/backend/escodegen/writer.wisp
+++ b/src/backend/escodegen/writer.wisp
@@ -11,7 +11,7 @@
                                   contains-vector? map-dictionary string?
                                   number? vector? boolean? subs re-find true?
                                   false? nil? re-pattern? inc dec str char
-                                  int = ==]]
+                                  int = == get]]
             [wisp.string :refer [split join upper-case replace triml]]
             [wisp.expander :refer [install-macro!]]
             [escodegen :refer [generate]]))
@@ -850,7 +850,7 @@
    `(aget (or ~target 0)
           ~property))
   ([target property default*]
-    (if (nil? default*)
+    (if (identical? default* nil)
       `(get ~target ~property)
       `(apply get ~[target property default*]))))
 (install-macro! :get get-macro)

--- a/src/backend/escodegen/writer.wisp
+++ b/src/backend/escodegen/writer.wisp
@@ -940,7 +940,7 @@
 (install-arithmetic-operator! :- :- #(>= % 1) 0)
 (install-arithmetic-operator! :* :* nil 1)
 (install-arithmetic-operator! (keyword \/) (keyword \/) #(>= % 1) 1)
-(install-arithmetic-operator! :mod (keyword \%) #(== % 2) 1)
+(install-arithmetic-operator! :rem (keyword \%) #(== % 2) 1)
 
 
 ;; Comparison operators

--- a/src/runtime.wisp
+++ b/src/runtime.wisp
@@ -8,17 +8,17 @@
 (defn complement
   "Takes a fn f and returns a fn that takes the same arguments as f,
   has the same effects, if any, and returns the opposite truth value."
-  [f] (fn 
+  [f] (fn
         ([] (not (f)))
         ([x] (not (f x)))
         ([x y] (not (f x y)))
         ([x y & zs] (not (apply f x y zs)))))
 
 (defn ^boolean odd? [n]
-  (identical? (mod n 2) 1))
+  (identical? (rem n 2) 1))
 
 (defn ^boolean even? [n]
-  (identical? (mod n 2) 0))
+  (identical? (rem n 2) 0))
 
 (defn ^boolean dictionary?
   "Returns true if dictionary"
@@ -521,6 +521,19 @@
               (inc index)
               count)
        value))))
+
+(defn ^boolean quot [num div] (int (/ num div)))
+(defn ^boolean mod [num div] (- num (* div (quot num div))))
+(defn ^boolean rem* [num div]
+  (let [m (apply mod [num div])]
+    (if (identical? (>= num 0) (>= div 0))
+      m
+      (- m div))))
+(def ^boolean rem
+  (if (let [rem #(identity nil)]    ; checking if rem is macro-shadowed
+        (nil? (rem 1 1)))
+    rem*
+    (fn [num div] (rem num div))))
 
 (defn ^boolean and
   ([] true)

--- a/src/runtime.wisp
+++ b/src/runtime.wisp
@@ -20,6 +20,12 @@
 (defn ^boolean even? [n]
   (identical? (rem n 2) 0))
 
+(defn get [target key default*]
+  (cond (set? target) (if (.has target key) key default*)
+        :else         (if (and target (.has-own-property target key))
+                        (aget target key)
+                        default*)))
+
 (defn ^boolean dictionary?
   "Returns true if dictionary"
   [form]

--- a/src/runtime.wisp
+++ b/src/runtime.wisp
@@ -332,21 +332,6 @@
                     false)
                   true))))))
 
-(defn- ^boolean vector-equal?
-  [x y]
-  (and (vector? x)
-       (vector? y)
-       (identical? (.-length x) (.-length y))
-       (loop [xs x
-              ys y
-              index 0
-              count (.-length x)]
-        (if (< index count)
-          (if (equivalent? (get xs index) (get ys index))
-              (recur xs ys (inc index) count)
-              false)
-          true))))
-
 (defn- ^boolean equivalent?
   "Equality. Returns true if x equals y, false if not. Compares
   numbers and collections in a type-independent manner. Clojure's
@@ -361,11 +346,11 @@
                    (number? x) (and (number? y) (identical? (.valueOf x)
                                                             (.valueOf y)))
                    (set? x) (set-equal? x y)
-                   (list? x) (and (list? y) (= (Array.from x) (Array.from y)))
+                   (or (vector? x) (list? x) (lazy-seq? x)) (and (or (vector? y) (list? y) (lazy-seq? y))
+                                                                 (=.*seq= x y))
                    (fn? x) false
                    (boolean? x) false
                    (date? x) (date-equal? x y)
-                   (vector? x) (vector-equal? x y)
                    (re-pattern? x) (pattern-equal? x y)
                    :else (dictionary-equal? x y))))
   ([x y & more]

--- a/src/sequence.wisp
+++ b/src/sequence.wisp
@@ -612,6 +612,14 @@
                    :else          (recur (rest xs))))
           (seq sequence)))
 
+(defn lazy-concat [& sequences]
+  (if-not (empty? sequences)
+    ((fn iter [xs]
+       (lazy-seq (if (empty? xs)
+                   (apply lazy-concat (rest sequences))
+                   (cons (first xs) (iter (rest xs))))))
+     (seq (first sequences)))))
+
 (defn lazy-partition
   ([n coll] (lazy-partition n n coll))
   ([n step coll] (lazy-partition n step [] coll))

--- a/src/sequence.wisp
+++ b/src/sequence.wisp
@@ -26,7 +26,7 @@
   (set! this.head head)
   (set! this.tail (or tail (list)))
   (set! this.length
-    (if (or (nil? this.tail) (number? (.-length this.tail)))
+    (if (or (nil? this.tail) (dictionary? this.tail) (number? (.-length this.tail)))
       (inc (count this.tail))))
   this)
 

--- a/src/sequence.wisp
+++ b/src/sequence.wisp
@@ -272,8 +272,7 @@
                     (list? sequence) (apply list (butlast (vec sequence)))
                     (lazy-seq? sequence) (butlast (lazy-seq-value sequence))
                     :else (butlast (seq sequence)))]
-    (if (not (or (nil? items) (empty? items)))
-        items)))
+    (if-not (empty? items) items)))
 
 (defn take
   "Returns a sequence of the first `n` items, or all items if
@@ -290,7 +289,7 @@
   (loop [items sequence, result []]
     (let [head (first items), tail (rest items)]
       (if (and (not (empty? items))
-                    (predicate head))
+               (predicate head))
         (recur tail (conj result head))
         (if (native? sequence) result (apply list result))))))
 

--- a/src/sequence.wisp
+++ b/src/sequence.wisp
@@ -1,7 +1,7 @@
 (ns wisp.sequence
   (:require [wisp.runtime :refer [nil? vector? fn? number? string? dictionary? set?
                                   key-values str int dec inc min merge dictionary
-                                  iterable? = complement]]))
+                                  iterable? = complement identity]]))
 
 ;; Implementation of list
 
@@ -620,3 +620,29 @@
                (if (and (not (empty? %)) (identical? n (count chunk)))
                  [chunk (drop step %)]))
             coll)))
+
+
+(defn run!
+  "Runs the supplied procedure (via reduce), for purposes of side
+  effects, on successive items in the collection. Returns nil"
+  [proc coll]
+  (reduce (fn [_ x] (proc x) nil) nil coll))
+
+(defn dorun
+  "When lazy sequences are produced via functions that have side
+  effects, any effects other than those needed to produce the first
+  element in the seq do not occur until the seq is consumed. dorun can
+  be used to force any effects. Walks through the successive nexts of
+  the seq, does not retain the head and returns nil."
+  ([coll] (dorun Infinity coll))
+  ([n coll] (run! identity (take n coll))))
+
+(defn doall
+  "When lazy sequences are produced via functions that have side
+  effects, any effects other than those needed to produce the first
+  element in the seq do not occur until the seq is consumed. dorun can
+  be used to force any effects. Walks through the successive nexts of
+  the seq, retains the head and returns it, thus causing the entire
+  seq to reside in memory at one time."
+  ([coll] (doall Infinity coll))
+  ([n coll] (dorun n coll) coll))

--- a/src/sequence.wisp
+++ b/src/sequence.wisp
@@ -525,3 +525,47 @@
                                   not-found)
         (lazy-seq? sequence) (nth (lazy-seq-value sequence) index not-found)
         :else (throw (TypeError "Unsupported type"))))
+
+
+(defn contains?
+  "Returns true if key is present in the given collection, otherwise
+  returns false.  Note that for numerically indexed collections like
+  vectors and strings, this tests if the numeric key is within the
+  range of indexes. 'contains?' operates constant or logarithmic time;
+  it will not perform a linear search for a value.  See also 'some'."
+  [coll v]
+  (cond (set? coll)                                           (.has coll v)
+        (or (dictionary? coll) (vector? coll) (string? coll)) (.has-own-property coll v)
+        :else                                                 false))
+
+(defn union
+  "Return a set that is the union of the input sets"
+  [& sets]
+  (into #{} (apply concat sets)))
+
+(defn difference
+  "Return a set that is the first set without elements of the remaining sets"
+  [s1 & sets]
+  (into #{} (filter (complement (apply union sets))
+                    s1)))
+
+(defn intersection
+  "Return a set that is the intersection of the input sets"
+  [& sets]
+  (let [sets     (mapv #(into #{} %) sets)
+        in-each? (fn [x] (every? #(.has % x) sets))
+        min-size (apply min (mapv count sets))
+        smallest (.find sets #(= min-size (count %)))]
+    (into #{} (filter in-each? smallest))))
+
+(defn subset?
+  "Is set1 a subset of set2?"
+  [set1 set2]
+  (if (set? set2)
+    (every? #(.has set2 %) set1)
+    (subset? set1 (into #{} set2))))
+
+(defn superset?
+  "Is set1 a superset of set2?"
+  [set1 set2]
+  (subset? set2 set1))

--- a/src/sequence.wisp
+++ b/src/sequence.wisp
@@ -193,7 +193,6 @@
 (defn count
   "Returns number of elements in list"
   [sequence]
-  (if (lazy-seq? sequence) (first sequence))   ; forcing evaluation
   (if (and sequence (number? (.-length sequence)))
     (.-length sequence)
     (let [it (seq sequence)]
@@ -283,7 +282,7 @@
   (cond (nil? sequence) '()
         (vector? sequence) (take-from-vector n sequence)
         (list? sequence) (take-from-list n sequence)
-        (lazy-seq? sequence) (take n (lazy-seq-value sequence))
+        (lazy-seq? sequence) (if (> n 0) (take n (lazy-seq-value sequence)))
         :else (take n (seq sequence))))
 
 (defn take-while

--- a/src/sequence.wisp
+++ b/src/sequence.wisp
@@ -91,6 +91,17 @@
 (def identity-set? identity-set?)
 (def list? list?)
 
+(set! =.*seq=
+  (fn [x y]
+    (and (or (vector? x) (seq? x))
+         (or (vector? y) (seq? y))
+         (loop [x (seq x), y (seq y)]
+           (cond (and (vector? x) (vector? y)) (and (= (count x) (count y))
+                                                    (.every x #(= %1 (aget y %2))))
+                 (or (empty? x) (empty? y))    (and (empty? x) (empty? y))
+                 (not= (first x) (first y))    false
+                 :else                         (recur (rest x) (rest y)))))))
+
 (defn list
   "Creates list of the given items"
   []

--- a/src/string.wisp
+++ b/src/string.wisp
@@ -35,7 +35,7 @@
   [string pattern limit]
   (if (not limit)
     (.split string pattern)
-    (clojure-split string pattern limit)))
+    (clojure-split string pattern (if (> limit 0) limit Infinity))))
 
 (defn split-lines
   "Splits s on \n or \r\n."

--- a/test/escodegen.wisp
+++ b/test/escodegen.wisp
@@ -330,14 +330,14 @@
 ;; functions
 
 
-(is (= (transpile "(fn [] (+ x y))")
+(is (= (transpile "(fn* [] (+ x y))")
 "(function () {
     return x + y;
 });"))
 
 ;; =>
 
-(is (= (transpile "(fn [x] (def y 7) (+ x y))")
+(is (= (transpile "(fn* [x] (def y 7) (+ x y))")
 "(function (x) {
     var y = 7;
     return x + y;
@@ -345,98 +345,98 @@
 
 ;; =>
 
-(is (= (transpile "(fn [])")
+(is (= (transpile "(fn* [])")
 "(function () {
     return void 0;
 });"))
 
 ;; =>
 
-(is (= (transpile "(fn ([]))")
+(is (= (transpile "(fn* ([]))")
 "(function () {
     return void 0;
 });"))
 
 ;; =>
 
-(is (= (transpile "(fn ([]))")
+(is (= (transpile "(fn* ([]))")
 "(function () {
     return void 0;
 });"))
 
 ;; =>
 
-(is (thrown? (transpile "(fn a b)")
+(is (thrown? (transpile "(fn* a b)")
              #"parameter declaration \(b\) must be a vector"))
 
 ;; =>
 
-(is (thrown? (transpile "(fn a ())")
+(is (thrown? (transpile "(fn* a ())")
              #"parameter declaration \(\(\)\) must be a vector"))
 
 ;; =>
 
-(is (thrown? (transpile "(fn a (b))")
+(is (thrown? (transpile "(fn* a (b))")
              #"parameter declaration \(\(b\)\) must be a vector"))
 
 ;; =>
 
-(is (thrown? (transpile "(fn)")
+(is (thrown? (transpile "(fn*)")
              #"parameter declaration \(nil\) must be a vector"))
 
 ;; =>
 
-(is (thrown? (transpile "(fn {} a)")
+(is (thrown? (transpile "(fn* {} a)")
              #"parameter declaration \({}\) must be a vector"))
 
 ;; =>
 
-(is (thrown? (transpile "(fn ([]) a)")
+(is (thrown? (transpile "(fn* ([]) a)")
              #"Malformed fn overload form"))
 
 ;; =>
 
-(is (thrown? (transpile "(fn ([]) (a))")
+(is (thrown? (transpile "(fn* ([]) (a))")
              #"Malformed fn overload form"))
 
 ;; =>
 
-(is (= (transpile "(fn [x] x)")
+(is (= (transpile "(fn* [x] x)")
        "(function (x) {\n    return x;\n});")
     "function compiles")
 
 ;; =>
 
-(is (= (transpile "(fn [x] (def y 1) (foo x y))")
+(is (= (transpile "(fn* [x] (def y 1) (foo x y))")
        "(function (x) {\n    var y = 1;\n    return foo(x, y);\n});")
     "function with multiple statements compiles")
 
 ;; =>
 
-(is (= (transpile "(fn identity [x] x)")
+(is (= (transpile "(fn* identity [x] x)")
                   "(function identity(x) {\n    return x;\n});")
     "named function compiles")
 
 ;; =>
 
-(is (thrown? (transpile "(fn \"doc\" a [x] x)")
+(is (thrown? (transpile "(fn* \"doc\" a [x] x)")
              #"parameter declaration (.*) must be a vector"))
 
 ;; =>
 
-(is (= (transpile "(fn foo? ^boolean [x] true)")
+(is (= (transpile "(fn* foo? ^boolean [x] true)")
        "(function isFoo(x) {\n    return true;\n});")
     "metadata is supported")
 
 ;; =>
 
-(is (= (transpile "(fn ^:static x [y] y)")
+(is (= (transpile "(fn* ^:static x [y] y)")
        "(function x(y) {\n    return y;\n});")
     "fn name metadata")
 
 ;; =>
 
-(is (= (transpile "(fn [a & b] a)")
+(is (= (transpile "(fn* [a & b] a)")
 "(function (a) {
     var b = Array.prototype.slice.call(arguments, 1);
     return a;
@@ -444,7 +444,7 @@
 
 ;; =>
 
-(is (= (transpile "(fn [& a] a)")
+(is (= (transpile "(fn* [& a] a)")
 "(function () {
     var a = Array.prototype.slice.call(arguments, 0);
     return a;
@@ -453,7 +453,7 @@
 
 ;; =>
 
-(is (= (transpile "(fn
+(is (= (transpile "(fn*
                      ([] 0)
                      ([x] x))")
 "(function () {
@@ -470,7 +470,7 @@
 
 ;; =>
 
-(is (= (transpile "(fn sum
+(is (= (transpile "(fn* sum
                     ([] 0)
                     ([x] x)
                     ([x y] (+ x y))
@@ -499,7 +499,7 @@
 
 ;; =>
 
-(is (= (transpile "(fn vector->list [v] (make list v))")
+(is (= (transpile "(fn* vector->list [v] (make list v))")
 "(function vectorToList(v) {
     return make(list, v);
 });"))
@@ -563,7 +563,7 @@
     return plus(a, b);
 })();"))
 
-(is (= (transpile "(fn [a]
+(is (= (transpile "(fn* [a]
                     (do
                       (def b 2)
                       (plus a b)))")
@@ -578,21 +578,21 @@
 
 ;; Let
 
-(is (= (transpile "(let [])")
+(is (= (transpile "(let* [])")
 "(function () {
     return void 0;
 }.call(this));"))
 
 ;; =>
 
-(is (= (transpile "(let [] x)")
+(is (= (transpile "(let* [] x)")
 "(function () {
     return x;
 }.call(this));"))
 
 ;; =>
 
-(is (= (transpile "(let [x 1 y 2] (+ x y))")
+(is (= (transpile "(let* [x 1 y 2] (+ x y))")
 "(function () {
     var xø1 = 1;
     var yø1 = 2;
@@ -601,8 +601,8 @@
 
 ;; =>
 
-(is (= (transpile "(let [x y
-                         y x]
+(is (= (transpile "(let* [x y
+                          y x]
                      [x y])")
 "(function () {
     var xø1 = y;
@@ -615,7 +615,7 @@
 
 ;; =>
 
-(is (= (transpile "(let []
+(is (= (transpile "(let* []
                      (+ x y))")
 "(function () {
     return x + y;
@@ -623,8 +623,8 @@
 
 ;; =>
 
-(is (= (transpile "(let [x 1
-                         y y]
+(is (= (transpile "(let* [x 1
+                          y y]
                      (+ x y))")
 "(function () {
     var xø1 = 1;
@@ -635,9 +635,9 @@
 
 ;; =>
 
-(is (= (transpile "(let [x 1
-                         x (inc x)
-                         x (dec x)]
+(is (= (transpile "(let* [x 1
+                          x (inc x)
+                          x (dec x)]
                      (+ x 5))")
 "(function () {
     var xø1 = 1;
@@ -648,9 +648,9 @@
 
 ;; =>
 
-(is (= (transpile "(let [x 1
-                         y (inc x)
-                         x (dec x)]
+(is (= (transpile "(let* [x 1
+                          y (inc x)
+                          x (dec x)]
                      (if x y (+ x 5)))")
 "(function () {
     var xø1 = 1;
@@ -661,7 +661,7 @@
 
 ;; =>
 
-(is (= (transpile "(let [x x] (fn [] x))")
+(is (= (transpile "(let* [x x] (fn* [] x))")
 "(function () {
     var xø1 = x;
     return function () {
@@ -671,7 +671,7 @@
 
 ;; =>
 
-(is (= (transpile "(let [x x] (fn [x] x))")
+(is (= (transpile "(let* [x x] (fn* [x] x))")
 "(function () {
     var xø1 = x;
     return function (x) {
@@ -681,7 +681,7 @@
 
 ;; =>
 
-(is (= (transpile "(let [x x] (fn x [] x))")
+(is (= (transpile "(let* [x x] (fn* x [] x))")
 "(function () {
     var xø1 = x;
     return function x() {
@@ -691,7 +691,7 @@
 
 ;; =>
 
-(is (= (transpile "(let [x x] (< x 2))")
+(is (= (transpile "(let* [x x] (< x 2))")
 "(function () {
     var xø1 = x;
     return xø1 < 2;
@@ -699,7 +699,7 @@
 
 ;; =>
 
-(is (= (transpile "(let [a a] a.a)")
+(is (= (transpile "(let* [a a] a.a)")
 "(function () {
     var aø1 = a;
     return aø1.a;
@@ -874,7 +874,7 @@
 ;; loop
 
 
-(is (= (transpile "(loop [x 10]
+(is (= (transpile "(loop* [x 10]
                         (if (< x 7)
                           (print x)
                           (recur (- x 2))))")
@@ -889,7 +889,7 @@
 
 ;; =>
 
-(is (= (transpile "(loop [forms forms
+(is (= (transpile "(loop* [forms forms
                              result []]
                         (if (empty? forms)
                           result

--- a/test/escodegen.wisp
+++ b/test/escodegen.wisp
@@ -1387,13 +1387,13 @@
 
 (is (= (transpile "(defprotocol IFoo)")
 "{
-    var IFoo = exports.IFoo = { wisp_core$IProtocol$id: 'user.wisp/IFoo' };
+    var IFoo = exports.IFoo = { 'wisp_core$IProtocol$id': 'user.wisp/IFoo' };
     IFoo;
 }") "protocol defined")
 
 (is (= (transpile "(defprotocol IBar \"optional docs\")")
 "{
-    var IBar = exports.IBar = { wisp_core$IProtocol$id: 'user.wisp/IBar' };
+    var IBar = exports.IBar = { 'wisp_core$IProtocol$id': 'user.wisp/IBar' };
     IBar;
 }") "optionally docs can be provided")
 
@@ -1404,20 +1404,26 @@
   (^clj -rest [coll]))")
 "{
     var ISeq = exports.ISeq = {
-            wisp_core$IProtocol$id: 'user.wisp/ISeq',
+            'wisp_core$IProtocol$id': 'user.wisp/ISeq',
             _first: function user_wisp$ISeq$First(self) {
-                var f = self === null ? user_wisp$ISeq$First.nil : self === void 0 ? user_wisp$ISeq$First.nil : 'else' ? self.user_wisp$ISeq$First || user_wisp$ISeq$First[Object.prototype.toString.call(self).replace('[object ', '').replace(/\\]$/, '')] || user_wisp$ISeq$First._ : void 0;
-                return f.apply(self, arguments);
+                return ((self === null || self === void 0 ? user_wisp$ISeq$First.nil : self.user_wisp$ISeq$First || user_wisp$ISeq$First[Object.prototype.toString.call(self).slice(8, -1)] || user_wisp$ISeq$First._) || function ($1) {
+                    return (function () {
+                        throw '' + 'No protocol method ISeq.user*wisp$ISeq$-first defined for type ' + Object.prototype.toString.call($1).slice(8, -1) + ': ' + $1;
+                    })();
+                }).apply(self, arguments);
             },
             _rest: function user_wisp$ISeq$Rest(self) {
-                var f = self === null ? user_wisp$ISeq$Rest.nil : self === void 0 ? user_wisp$ISeq$Rest.nil : 'else' ? self.user_wisp$ISeq$Rest || user_wisp$ISeq$Rest[Object.prototype.toString.call(self).replace('[object ', '').replace(/\\]$/, '')] || user_wisp$ISeq$Rest._ : void 0;
-                return f.apply(self, arguments);
+                return ((self === null || self === void 0 ? user_wisp$ISeq$Rest.nil : self.user_wisp$ISeq$Rest || user_wisp$ISeq$Rest[Object.prototype.toString.call(self).slice(8, -1)] || user_wisp$ISeq$Rest._) || function ($1) {
+                    return (function () {
+                        throw '' + 'No protocol method ISeq.user*wisp$ISeq$-rest defined for type ' + Object.prototype.toString.call($1).slice(8, -1) + ': ' + $1;
+                    })();
+                }).apply(self, arguments);
             }
         };
     var _first = exports._first = ISeq._first;
     var _rest = exports._rest = ISeq._rest;
     ISeq;
-}") "methods can are also generated & exported")
+}") "methods can also be generated & exported")
 
 (is (= (transpile
 "(ns wisp.core)
@@ -1433,14 +1439,20 @@
 }
 {
     var ISeq = exports.ISeq = {
-            wisp_core$IProtocol$id: 'wisp.core/ISeq',
+            'wisp_core$IProtocol$id': 'wisp.core/ISeq',
             _first: function wisp_core$ISeq$First(self) {
-                var f = self === null ? wisp_core$ISeq$First.nil : self === void 0 ? wisp_core$ISeq$First.nil : 'else' ? self.wisp_core$ISeq$First || wisp_core$ISeq$First[Object.prototype.toString.call(self).replace('[object ', '').replace(/\\]$/, '')] || wisp_core$ISeq$First._ : void 0;
-                return f.apply(self, arguments);
+                return ((self === null || self === void 0 ? wisp_core$ISeq$First.nil : self.wisp_core$ISeq$First || wisp_core$ISeq$First[Object.prototype.toString.call(self).slice(8, -1)] || wisp_core$ISeq$First._) || function ($1) {
+                    return (function () {
+                        throw '' + 'No protocol method ISeq.wisp*core$ISeq$-first defined for type ' + Object.prototype.toString.call($1).slice(8, -1) + ': ' + $1;
+                    })();
+                }).apply(self, arguments);
             },
             _rest: function wisp_core$ISeq$Rest(self) {
-                var f = self === null ? wisp_core$ISeq$Rest.nil : self === void 0 ? wisp_core$ISeq$Rest.nil : 'else' ? self.wisp_core$ISeq$Rest || wisp_core$ISeq$Rest[Object.prototype.toString.call(self).replace('[object ', '').replace(/\\]$/, '')] || wisp_core$ISeq$Rest._ : void 0;
-                return f.apply(self, arguments);
+                return ((self === null || self === void 0 ? wisp_core$ISeq$Rest.nil : self.wisp_core$ISeq$Rest || wisp_core$ISeq$Rest[Object.prototype.toString.call(self).slice(8, -1)] || wisp_core$ISeq$Rest._) || function ($1) {
+                    return (function () {
+                        throw '' + 'No protocol method ISeq.wisp*core$ISeq$-rest defined for type ' + Object.prototype.toString.call($1).slice(8, -1) + ': ' + $1;
+                    })();
+                }).apply(self, arguments);
             }
         };
     var _first = exports._first = ISeq._first;
@@ -1453,7 +1465,7 @@
 "(defprotocol ^:private Fn
   \"Marker protocol\")")
 "{
-    var Fn = { wisp_core$IProtocol$id: 'user.wisp/Fn' };
+    var Fn = { 'wisp_core$IProtocol$id': 'user.wisp/Fn' };
     Fn;
 }") "protocol defs can be private")
 
@@ -1463,14 +1475,20 @@
   (bar []))")
 "{
     var IFooBar = {
-            wisp_core$IProtocol$id: 'user.wisp/IFooBar',
+            'wisp_core$IProtocol$id': 'user.wisp/IFooBar',
             foo: function user_wisp$IFooBar$foo(self) {
-                var f = self === null ? user_wisp$IFooBar$foo.nil : self === void 0 ? user_wisp$IFooBar$foo.nil : 'else' ? self.user_wisp$IFooBar$foo || user_wisp$IFooBar$foo[Object.prototype.toString.call(self).replace('[object ', '').replace(/\\]$/, '')] || user_wisp$IFooBar$foo._ : void 0;
-                return f.apply(self, arguments);
+                return ((self === null || self === void 0 ? user_wisp$IFooBar$foo.nil : self.user_wisp$IFooBar$foo || user_wisp$IFooBar$foo[Object.prototype.toString.call(self).slice(8, -1)] || user_wisp$IFooBar$foo._) || function ($1) {
+                    return (function () {
+                        throw '' + 'No protocol method IFooBar.user*wisp$IFooBar$foo defined for type ' + Object.prototype.toString.call($1).slice(8, -1) + ': ' + $1;
+                    })();
+                }).apply(self, arguments);
             },
             bar: function user_wisp$IFooBar$bar(self) {
-                var f = self === null ? user_wisp$IFooBar$bar.nil : self === void 0 ? user_wisp$IFooBar$bar.nil : 'else' ? self.user_wisp$IFooBar$bar || user_wisp$IFooBar$bar[Object.prototype.toString.call(self).replace('[object ', '').replace(/\\]$/, '')] || user_wisp$IFooBar$bar._ : void 0;
-                return f.apply(self, arguments);
+                return ((self === null || self === void 0 ? user_wisp$IFooBar$bar.nil : self.user_wisp$IFooBar$bar || user_wisp$IFooBar$bar[Object.prototype.toString.call(self).slice(8, -1)] || user_wisp$IFooBar$bar._) || function ($1) {
+                    return (function () {
+                        throw '' + 'No protocol method IFooBar.user*wisp$IFooBar$bar defined for type ' + Object.prototype.toString.call($1).slice(8, -1) + ': ' + $1;
+                    })();
+                }).apply(self, arguments);
             }
         };
     var foo = IFooBar.foo;
@@ -1483,10 +1501,13 @@
   (^number -count [coll] \"constant time count\"))")
 "{
     var ICounted = exports.ICounted = {
-            wisp_core$IProtocol$id: 'user.wisp/ICounted',
+            'wisp_core$IProtocol$id': 'user.wisp/ICounted',
             _count: function user_wisp$ICounted$Count(self) {
-                var f = self === null ? user_wisp$ICounted$Count.nil : self === void 0 ? user_wisp$ICounted$Count.nil : 'else' ? self.user_wisp$ICounted$Count || user_wisp$ICounted$Count[Object.prototype.toString.call(self).replace('[object ', '').replace(/\\]$/, '')] || user_wisp$ICounted$Count._ : void 0;
-                return f.apply(self, arguments);
+                return ((self === null || self === void 0 ? user_wisp$ICounted$Count.nil : self.user_wisp$ICounted$Count || user_wisp$ICounted$Count[Object.prototype.toString.call(self).slice(8, -1)] || user_wisp$ICounted$Count._) || function ($1) {
+                    return (function () {
+                        throw '' + 'No protocol method ICounted.user*wisp$ICounted$-count defined for type ' + Object.prototype.toString.call($1).slice(8, -1) + ': ' + $1;
+                    })();
+                }).apply(self, arguments);
             }
         };
     var _count = exports._count = ICounted._count;

--- a/test/escodegen.wisp
+++ b/test/escodegen.wisp
@@ -1325,16 +1325,16 @@
 
 ;; =>
 
-(is (thrown? (transpile "(mod)")
-             #"Wrong number of arguments \(0\) passed to: mod"))
+(is (thrown? (transpile "(rem)")
+             #"Wrong number of arguments \(0\) passed to: rem"))
 ;; =>
 
-(is (thrown? (transpile "(mod 1)")
-             #"Wrong number of arguments \(1\) passed to: mod"))
+(is (thrown? (transpile "(rem 1)")
+             #"Wrong number of arguments \(1\) passed to: rem"))
 
 ;; =>
 
-(is (= (transpile "(mod 1 2)")
+(is (= (transpile "(rem 1 2)")
        "1 % 2;"))
 ;; =>
 

--- a/test/macros.wisp
+++ b/test/macros.wisp
@@ -1,0 +1,342 @@
+(ns wisp.test.macros
+  (:require [wisp.test.util :refer [is thrown?]]
+            [wisp.runtime :refer [= dictionary? vector? list? lazy-seq? inc odd? keys]]
+            [wisp.sequence :refer [list vec third count range infinite-range take
+                                   lazy-seq empty? first rest cons lazy-concat dorun]]
+            [wisp.ast :refer [symbol? name namespace]]
+            [wisp.expander :refer [dot-syntax? method-syntax? field-syntax? new-syntax?
+                                   keyword-invoke macroexpand macroexpand-1]]))
+
+(defn- *expansion-matches [x y]
+  (let [gensym? #(and (symbol? %) (. (name %) includes \#))
+        gensyms {}, inv {}]
+    ((fn *matches [x y]
+       (cond (gensym? y)     (and (symbol? x)
+                                  (if-let [z (aget gensyms y)]
+                                    (= x z)
+                                    (if (aget inv x)
+                                      false
+                                      (do (aset gensyms y x)
+                                          (aset inv x y)
+                                          (. (name x) starts-with (. (name y) replace #"#.*" ""))))))
+             (symbol? y)     (and (symbol? x) (= (name x) (name y)) (= (namespace x) (namespace y)))
+             (vector? y)     (and (vector? x) (= (count x) (count y)) (.every x #(*matches %1 (aget y %2))))
+             (list? y)       (and (list? x) (*matches (vec x) (vec y)))
+             (dictionary? y) (and (dictionary? x) (*matches (.sort (keys x)) (.sort (keys y)))
+                                  (.every (keys x) #(*matches (aget x %) (aget y %))))
+             :else       (= x y)))
+     x y)))
+(def *= *expansion-matches)
+
+(defn- *side-effects! [f]
+  (let [xs [],  side-effect! (fn [x] (.push! xs x) x)]
+    [xs (f side-effect!)]))
+
+
+(is (dot-syntax? '.)           ". is dot-syntax?")
+(is (not (dot-syntax? '.foo))  ".foo is not dot-syntax?")
+(is (not (dot-syntax? '.-foo)) ".-foo is not dot-syntax?")
+(is (not (dot-syntax? 'foo.))  "foo. is not dot-syntax?")
+(is (not (dot-syntax? ':foo))  ":foo is not dot-syntax?")
+(is (not (dot-syntax? :foo))   "\"foo\" is not dot-syntax?")
+
+(is (not (method-syntax? '.))     ". is not method-syntax?")
+(is (method-syntax? '.foo)        ".foo is method-syntax?")
+(is (not (method-syntax? '.-foo)) ".-foo is not method-syntax?")
+(is (not (method-syntax? 'foo.))  "foo. is not method-syntax?")
+(is (not (method-syntax? ':foo))  ":foo is not method-syntax?")
+(is (not (method-syntax? :foo))   "\"foo\" is not method-syntax?")
+
+(is (not (field-syntax? '.))     ". is not field-syntax?")
+(is (not (field-syntax? '.foo))  ".foo is not field-syntax?")
+(is (field-syntax? '.-foo)       ".-foo is field-syntax?")
+(is (not (field-syntax? 'foo.))  "foo. is not field-syntax?")
+(is (not (field-syntax? ':foo))  ":foo is not field-syntax?")
+(is (not (field-syntax? :foo))   "\"foo\" is not field-syntax?")
+
+(is (not (new-syntax? '.))     ". is not new-syntax?")
+(is (not (new-syntax? '.foo))  ".foo is not new-syntax?")
+(is (not (new-syntax? '.-foo)) ".-foo is not new-syntax?")
+(is (new-syntax? 'foo.)        "foo. is new-syntax?")
+(is (not (new-syntax? ':foo))  ":foo is not new-syntax?")
+(is (not (new-syntax? :foo))   "\"foo\" is not new-syntax?")
+
+
+(is (= (macroexpand-1 '(.-foo bar))
+       '(aget bar 'foo)))
+
+(is (= (macroexpand-1 '(.foo bar baz x y z))
+       '((aget bar 'foo) baz x y z)))
+
+(is (= (macroexpand-1 '(. foo -bar))
+       '(aget foo 'bar)))
+(is (= (macroexpand-1 '(. foo bar baz x y z))
+       '((aget foo 'bar) baz x y z)))
+
+(is (= (macroexpand-1 '(Foo. bar baz))
+       '(new Foo bar baz)))
+
+(is (= (macroexpand-1 '(:foo bar))
+       '(get bar :foo)))
+(is (= (macroexpand-1 '(:foo bar baz))
+       '(get bar :foo baz)))
+
+(is (= (macroexpand-1 '(get bar :foo))
+       '(aget (or bar 0) :foo)))
+(is (= (macroexpand-1 '(get bar :foo baz))
+       '(apply get [bar :foo baz])))
+(is (= (macroexpand-1 '(get bar :foo nil))
+       '(get bar :foo)))
+(is (= (macroexpand-1 '(get bar :foo null))
+       '(apply get [bar :foo null])))
+
+
+(is (= (let [foo :bar, baz "abc"]
+         `(~foo bar ~@baz ~(+ 1 2) 42))
+       '("bar" bar \a \b \c 3 42)))
+
+
+(is (= (macroexpand-1 '(not= foo bar baz))
+       '(not (= foo bar baz))))
+
+(is (= (macroexpand '(comment foo bar baz))
+       nil))
+
+
+(is (= (macroexpand-1 '(-> x (foo) (bar 42) baz))
+       '(baz (bar (foo x) 42))))
+
+(is (= (macroexpand-1 '(->> x (foo) (bar 42) baz))
+       '(baz (bar 42 (foo x)))))
+
+(is (= (macroexpand-1 '(.. x (foo) (bar 42) -baz))
+       '(-> x (. foo) (. bar 42) (. -baz))))
+(is (= (macroexpand '(.. x (foo) (bar 42) -baz))
+       '(aget (. (. x foo) bar 42) 'baz)))
+
+
+(is (= (macroexpand-1 '(cond foo   bar
+                           :else baz))
+       '(if foo bar (cond :else baz))))
+(is (= (macroexpand-1 '(cond :else baz))
+       '(if :else baz (cond))))
+(is (= (macroexpand-1 '(cond))
+       nil))
+
+(is (= (macroexpand-1 '(defn foo []))
+       '(def foo (fn foo []))))
+(is (= (macroexpand-1 '(defn foo [bar baz] 1 2 3))
+       '(def foo (fn foo [bar baz] 1 2 3))))
+(is (= (macroexpand-1 '(defn foo
+                         ([bar] 1)
+                         ([& baz] 1 2 3))
+       '(def foo (fn foo
+                   ([bar] 1)
+                   ([& baz] 1 2 3))))))
+;; metadata doesn't seem to be accessible in runtime
+
+
+(is (= (macroexpand-1 '(lazy-seq (foo bar baz)))
+       '(.call lazy-seq nil false #(foo bar baz))))
+(is (= (macroexpand-1 '(lazy-seq [foo bar baz]))
+       '(.call lazy-seq nil false (fn [] [foo bar baz]))))
+
+
+(is (= (macroexpand-1 '(if-not foo bar))
+       '(if (not foo) bar nil)))
+(is (= (macroexpand-1 '(if-not foo bar baz))
+       '(if (not foo) bar baz)))
+
+(is (= (macroexpand-1 '(when foo
+                         bar
+                         baz))
+       '(if foo
+          (do bar
+              baz))))
+
+(is (= (macroexpand-1 '(when-not foo
+                         bar
+                         baz))
+       '(when (not foo)
+          bar
+          baz)))
+
+(is (*= (macroexpand-1 '(if-let [x (foo)]
+                          bar
+                          baz))
+        '(let [x# (foo)]
+           (if x#
+             (let [x x#] bar)
+             baz))))
+(is (*= (macroexpand-1 '(if-let [[x & xs] (foo)]
+                          bar
+                          baz))
+        '(let [G__# (foo)]
+           (if G__#
+             (let [[x & xs] G__#] bar)
+             baz))))
+
+(is (= (macroexpand-1 '(when-let [x (foo)]
+                         bar
+                         baz))
+       '(if-let [x (foo)] (do bar baz))))
+
+(is (= (macroexpand-1 '(while foo
+                         bar
+                         baz))
+       '(loop []
+          (when foo
+             bar
+             baz
+             (recur)))))
+
+
+(is (*= (macroexpand-1 '(doto (Map.)
+                          (.set :a 1)
+                          (.set :b 2)))
+        '(let [doto-binding# (Map.)]
+           (.set doto-binding# :a 1)
+           (.set doto-binding# :b 2)
+           doto-binding#)))
+
+(is (*= (macroexpand-1 '(dotimes [i 5]
+                          foo
+                          bar
+                          (baz i)))
+        `(let [dotimes-binding# 5]
+           (loop [i 0]
+             (when (< i dotimes-binding#)
+               foo
+               bar
+               (baz i)
+               (recur (inc i)))))))
+
+
+(is (lazy-seq? (for [x (range 10)] (- x)))
+    "for produces a lazy-seq")
+(is (= (vec (for [x (range 10)] (* x x)))
+       [0 1 4 9 16 25 36 49 64 81]))
+(is (= (vec (for [x (range 10), :let [y (inc x)]] (* y y)))
+       [1 4 9 16 25 36 49 64 81 100]))
+(is (= (vec (for [x (range 10), :when (odd? x)] (* x x)))
+       [1 9 25 49 81]))
+(is (= (vec (for [x (infinite-range 0 3), :while (< x 11)] (* x x)))
+       [0 9 36 81]))
+(is (= (vec (for [x (infinite-range 0 3), :while (< x 9), y "abc"] (str y x)))
+       [:a0 :b0 :c0 :a3 :b3 :c3 :a6 :b6 :c6]))
+(is (= (vec (for [x (range 0 10 3), :when (odd? x), y "abc"] (str y x)))
+       [:a3 :b3 :c3 :a9 :b9 :c9]))
+(is (= (vec (for [x (range 0 10 3), y "abc", :while (odd? x)] (str y x)))
+       [:a3 :b3 :c3 :a9 :b9 :c9]))
+(is (= (vec (take 20 (for [x (infinite-range), y (infinite-range), :while (< y x)]  [x y])))
+       [[1 0] [2 0] [2 1] [3 0] [3 1]  [3 2] [4 0] [4 1] [4 2] [4 3]
+        [5 0] [5 1] [5 2] [5 3] [5 4]  [6 0] [6 1] [6 2] [6 3] [6 4]]))
+
+(is (= (*side-effects! #(doseq [x "abc", y (range 3), :when (= (= x :b) (odd? y))]
+                          (% (str x y))))
+       [[:a0 :a2 :b1 :c0 :c2] nil]))
+
+
+(is (= (macroexpand-1 '(let [foo bar] baz))
+       '(let* [foo bar] baz)))
+(is (*= (macroexpand-1
+          '(let [[x1 _ x3 _ x5 _ [x7a x7b] & {:keys [lest] :as remaining} :as all] (foo stuff)
+                 bar                                                               (lest)
+                 {category :category-name, :keys [foo bar baz],
+                  :strs [first-name last-name], :syms [sym-name]
+                  :person/keys [name age], hobby hobby/hobby-name,
+                  :or {category "Category not found", foo 42, age 0}}              (bar x1)]
+             body))
+        '(let* [all                (foo stuff)
+                x1                 (nth all 0)
+                x3                 (nth all 2)
+                x5                 (nth all 4)
+                destructure-bind#1 (nth all 6)
+                x7a                (nth destructure-bind#1 0)
+                x7b                (nth destructure-bind#1 1)
+                remaining          (drop 7 all)
+                remaining          (if (dictionary? remaining)
+                                     remaining
+                                     (apply dictionary (vec remaining)))
+                lest               (get remaining ':lest nil)
+                bar                (lest)
+                destructure-bind#2 (bar x1)
+                destructure-bind#2 (if (dictionary? destructure-bind#2)
+                                     destructure-bind#2
+                                     (apply dictionary (vec destructure-bind#2)))
+                category           (get destructure-bind#2 :category-name "Category not found")
+                foo                (get destructure-bind#2 ':foo 42)
+                bar                (get destructure-bind#2 ':bar nil)
+                baz                (get destructure-bind#2 ':baz nil)
+                first-name         (get destructure-bind#2 :first-name nil)
+                last-name          (get destructure-bind#2 :last-name nil)
+                sym-name           (get destructure-bind#2 :symName nil)
+                name               (get destructure-bind#2 ':person/name nil)
+                age                (get destructure-bind#2 ':person/age 0)
+                hobby              (get destructure-bind#2 :hobby/hobbyName nil)]
+           body)))
+
+
+(is (= (macroexpand-1 '(fn [foo bar] baz))
+       '(fn* [foo bar] baz)))
+(is (= (macroexpand-1 '(fn name [foo bar] baz))
+       '(fn* name [foo bar] baz)))
+(is (= (macroexpand-1 '(fn
+                         ([] foo)
+                         ([bar] baz)))
+       '(fn*
+          ([] foo)
+          ([bar] baz))))
+(is (= (macroexpand-1 '(fn name
+                         ([] foo)
+                         ([bar] baz)))
+       '(fn* name
+          ([] foo)
+          ([bar] baz))))
+(is (*= (macroexpand-1
+          '(fn [[x1 _ x3 _ x5 _ [x7a x7b] & {:keys [lest] :as remaining} :as all]
+                bar
+                {category :category, :keys [foo bar baz]
+                 :strs [first-name last-name], :syms [sym-name]
+                 :person/keys [name age], hobby :hobby/name
+                 :or {category "Category not found", foo 42, age 0}}
+                & {:strs [opt-arg] :or {opt-arg :default}}]
+            body))
+        '(fn* [destructure-bind#1 bar destructure-bind#2 & destructure-bind#3]
+           (let [[x1 _ x3 _ x5 _ [x7a x7b] & {:keys [lest] :as remaining} :as all] destructure-bind#1
+                 {category :category, :keys [foo bar baz]
+                  :strs [first-name last-name], :syms [sym-name]
+                  :person/keys [name age], hobby :hobby/name,
+                  :or {category "Category not found", foo 42, age 0}}              destructure-bind#2
+                 {:strs [opt-arg] :or {opt-arg :default}}                          destructure-bind#3]
+             body))))
+
+(is (= (macroexpand-1 '(loop [foo bar] baz))
+       '(loop* [foo bar] baz)))
+(is (*= (macroexpand-1
+          '(loop [[x1 _ x3 _ x5 _ [x7a x7b] & {:keys [lest] :as remaining} :as all] (foo stuff)
+                  bar                                                               (lest)
+                  {category :category, :keys [foo bar baz],
+                   :strs [first-name last-name], :syms [sym-name]
+                   :person/keys [name age], hobby hobby/hobby-name,
+                   :or {category "Category not found", foo 42, age 0}}              (bar x1)]
+             (if done
+               result
+               (recur foo bar baz))))
+        '(let [destructure-bind#1                                                (foo stuff)
+               [x1 _ x3 _ x5 _ [x7a x7b] & {:keys [lest] :as remaining} :as all] destructure-bind#1
+               bar                                                               (lest)
+               destructure-bind#2                                                (bar x1)
+               {category :category, :keys [foo bar baz],
+                :strs [first-name last-name], :syms [sym-name]
+                :person/keys [name age], hobby hobby/hobby-name,
+                :or {category "Category not found", foo 42, age 0}}              destructure-bind#2]
+           (loop* [destructure-bind#1 destructure-bind#1, bar bar, destructure-bind#2 destructure-bind#2]
+             (let [[x1 _ x3 _ x5 _ [x7a x7b] & {:keys [lest] :as remaining} :as all] destructure-bind#1
+                   {category :category, :keys [foo bar baz]
+                    :strs [first-name last-name], :syms [sym-name]
+                    :person/keys [name age], hobby hobby/hobby-name,
+                    :or {category "Category not found", foo 42, age 0}}              destructure-bind#2]
+               (if done
+                 result
+                 (recur foo bar baz)))))))

--- a/test/runtime.wisp
+++ b/test/runtime.wisp
@@ -2,7 +2,7 @@
   (:require [wisp.test.util :refer [is thrown?]]
             [wisp.src.runtime :refer [dictionary? vector? iterable? set?
                                       subs str and or = == > >= < <=
-                                      + - / * nan?]]
+                                      + - / * quot mod rem rem* nan?]]
             [wisp.src.sequence :refer [list concat vec]]
             [wisp.src.ast :refer [symbol]]))
 
@@ -117,6 +117,38 @@
 (is (= (apply / [6 2]) 3))
 (is (= (apply / [10 2 3]) 5/3))
 (is (= (apply / [30 1 2 3 4 5 6]) 1/24))
+
+(is (= (apply quot [ 10  3])  3))
+(is (= (apply quot [-10  3]) -4))  ; difference from Clojure: int rounds down, not towards zero
+(is (= (apply quot [ 10 -3]) -4))
+(is (= (apply quot [-10 -3])  3))
+(is (= (apply quot [ 1024.8402 5.12])  200))
+(is (= (apply quot [-1024.8402 5.12]) -201))
+
+(defn- approx= [x delta & xs]
+  (.every xs #(> delta (Math.abs (- x %)))))
+
+(is (= (apply mod [ 10  3])  1))
+(is (= (apply mod [-10  3])  2))
+(is (= (apply mod [ 10 -3]) -2))
+(is (= (apply mod [-10 -3]) -1))
+(is (approx= (apply mod [ 1024.8402 5.12]) 1e-5 0.8402))
+(is (approx= (apply mod [-1024.8402 5.12]) 1e-5 4.2798))
+
+(is (= (apply rem  [ 10  3])  1))
+(is (= (apply rem  [-10  3]) -1))
+(is (= (apply rem  [ 10 -3])  1))
+(is (= (apply rem  [-10 -3]) -1))
+(is (= (apply rem* [ 10  3])  1))
+(is (= (apply rem* [-10  3]) -1))
+(is (= (apply rem* [ 10 -3])  1))
+(is (= (apply rem* [-10 -3]) -1))
+(is (approx= (apply rem  [ 1024.8402 5.12]) 1e-5  0.8402))
+(is (approx= (apply rem  [-1024.8402 5.12]) 1e-5 -0.8402))
+(is (approx= (apply rem* [ 1024.8402 5.12]) 1e-5  0.8402))
+(is (approx= (apply rem* [-1024.8402 5.12]) 1e-5 -0.8402))
+
+
 
 (is (= (apply and []) true))
 (is (= (apply and [1]) 1))

--- a/test/runtime.wisp
+++ b/test/runtime.wisp
@@ -3,7 +3,8 @@
             [wisp.src.runtime :refer [dictionary? vector? iterable? set?
                                       subs str and or = == not= > >= < <=
                                       + - / * quot mod rem rem* nan?]]
-            [wisp.src.sequence :refer [list cons concat vec lazy-seq]]
+            [wisp.src.sequence :refer [list cons concat vec lazy-seq seq set
+                                       take range infinite-range lazy-concat]]
             [wisp.src.ast :refer [symbol]]))
 
 
@@ -43,7 +44,6 @@
 (is (not (apply = [1 2 3])))
 (is (apply = [1 1 1 1 1 1]))
 (is (not (apply = [1 1 1 1 2 1])))
-(is (= '(1 2 3) (cons 1 [2 3])))
 
 (is (apply == [1]))
 (is (apply == [1 1]))
@@ -215,6 +215,16 @@
               {:x 1 :y [2 [3 {:z 4}]]}
               {:x 1 :y [2 [3 {:z 4}]]}
               {:x 1 :y [2 [3 {:z 4}]]}]))
+(is (= '(1 2 3) (cons 1 [2 3])))
+(is (= '(1 2 3) [1 2 3]))
+(is (= (range 10) (take 10 (infinite-range))))
+(is (= (range 10) (seq (Set. (range 10)))))
+(is (not= (range 10) (infinite-range)))
+(is (not= (infinite-range 1) (infinite-range 1 2)))
+(is (= (lazy-concat (range 10) \+ (range 2))
+       (lazy-concat (range 10) \+ #{0 1})))
+(is (not= (lazy-concat (range 10) \+ (infinite-range 1))
+          (lazy-concat (range 10) \+ (infinite-range 1 2))))
 
 (is (not (apply not= [])))
 (is (not (apply not= [1 1])))

--- a/test/runtime.wisp
+++ b/test/runtime.wisp
@@ -1,9 +1,9 @@
 (ns wisp.test.runtime
   (:require [wisp.test.util :refer [is thrown?]]
             [wisp.src.runtime :refer [dictionary? vector? iterable? set?
-                                      subs str and or = == > >= < <=
+                                      subs str and or = == not= > >= < <=
                                       + - / * quot mod rem rem* nan?]]
-            [wisp.src.sequence :refer [list concat vec]]
+            [wisp.src.sequence :refer [list cons concat vec lazy-seq]]
             [wisp.src.ast :refer [symbol]]))
 
 
@@ -18,8 +18,9 @@
 (is (vector? []) "[] is vector")
 
 (is (not (iterable? nil)) "nil is not iterable")
-(is (not (iterable? '())) "() is not iterable")
 (is (not (iterable? {})) "{} is not iterable")
+(is (iterable? '()) "() is iterable")
+(is (iterable? (lazy-seq)) "(lazy-seq) is iterable")
 (is (iterable? []) "[] is iterable")
 (is (iterable? (Set.)) "Set{} is iterable")
 (is (iterable? (.keys (Set.))) "(.keys Set{}) is iterable")
@@ -42,6 +43,7 @@
 (is (not (apply = [1 2 3])))
 (is (apply = [1 1 1 1 1 1]))
 (is (not (apply = [1 1 1 1 2 1])))
+(is (= '(1 2 3) (cons 1 [2 3])))
 
 (is (apply == [1]))
 (is (apply == [1 1]))
@@ -213,6 +215,13 @@
               {:x 1 :y [2 [3 {:z 4}]]}
               {:x 1 :y [2 [3 {:z 4}]]}
               {:x 1 :y [2 [3 {:z 4}]]}]))
+
+(is (not (apply not= [])))
+(is (not (apply not= [1 1])))
+(is (apply not= [1 2]))
+(is (apply not= [1 "1"]))
+(is (apply not= [1 :1]))
+(is (apply not= ["b" 'b]))
 
 (is (= (apply nan? []) true))
 (is (= (apply nan? [nil]) true))

--- a/test/sequence.wisp
+++ b/test/sequence.wisp
@@ -621,7 +621,7 @@
 
 
 (defn- binary* [n]    ; unfolder to binary form (reversed)
-  (if (> n 0) [(mod n 2) (int (/ n 2))]))
+  (if (> n 0) [(rem n 2) (int (/ n 2))]))
 (is (= (vec (unfold binary*  0)) []))
 (is (= (vec (unfold binary* 13)) [1 0 1 1]))      ; 1 + 4 + 8
 (is (= (vec (unfold binary* 42)) [0 1 0 1 0 1]))  ; 2 + 8 + 32

--- a/test/sequence.wisp
+++ b/test/sequence.wisp
@@ -5,7 +5,8 @@
                                        butlast take take-while drop drop-while repeat concat
                                        mapcat reverse sort map mapv map-indexed filter
                                        filterv reduce assoc dissoc every? some partition
-                                       interleave nth lazy-seq set identity-set identity-set?]]
+                                       interleave nth lazy-seq set identity-set identity-set?
+                                       contains? union difference intersection subset? superset?]]
             [wisp.src.runtime :refer [str inc dec even? odd? number? set? vals + =]]))
 
 
@@ -583,3 +584,35 @@
 (is (= (nth [1 2 3 4] 2) 3))
 (is (= (nth [1 2 3 4] 0) 1))
 (is (= (nth (seq {:foo 1 :bar 2}) 1) [:bar 2]))
+
+
+(is (contains? #{2 1 3} 3)           "contains? on sets checks for membership")
+(is (not (contains? #{2 1 3} 0))     "contains? on sets checks for membership")
+(is (contains? {:a 1, :b 2} :a)      "contains? on dictionaries checks for key existence")
+(is (not (contains? {:a 1, :b 2} 1)) "contains? on dictionaries checks for key existence")
+(is (contains? [:a :b :c] 1)         "contains? on vectors checks for index existence")
+(is (not (contains? [:a :b :c] :b))  "contains? on vectors checks for index existence")
+(is (contains? "foo" 2)              "contains? on strings checks for index existence")
+(is (not (contains? "foo" \f))       "contains? on strings checks for index existence")
+(is (not (contains? (list 1 2 3) 1)) "contains? on other types returns false")
+
+(is (= (union) #{}))
+(is (= (union [1 2 3]) #{1 2 3}))
+(is (= (union :foo [\b \a \r] "baz")
+       #{:a :b :f :o :r :z}))
+
+(is (= (difference [1 2 3]) #{1 2 3}))
+(is (= (difference [\b \a \r] "baz") #{:r}))
+(is (= (difference [\b \a \r] "baz" :answer) #{}))
+
+(is (= (intersection [1 2 3]) #{1 2 3}))
+(is (= (intersection [\b \a \r] "baz") #{:a :b}))
+(is (= (intersection [\b \a \r] "baz" :answer) #{:a}))
+
+(is (subset? nil [42])          "subset? checks if all items from set1 are in set2")
+(is (subset? :foo "of")         "subset? works on equal sets")
+(is (not (subset? "bar" "baz")) "subset? works on different sets")
+
+(is (superset? [42] nil)          "superset? checks if all items from set2 are in set1")
+(is (superset? :of "foo")         "superset? works on equal sets")
+(is (not (superset? "baz" "bar")) "superset? works on different sets")

--- a/test/sequence.wisp
+++ b/test/sequence.wisp
@@ -6,8 +6,10 @@
                                        mapcat reverse sort map mapv map-indexed filter
                                        filterv reduce assoc dissoc every? some partition
                                        interleave nth lazy-seq set identity-set identity-set?
-                                       contains? union difference intersection subset? superset?]]
-            [wisp.src.runtime :refer [str inc dec even? odd? number? set? vals + =]]))
+                                       contains? union difference intersection subset? superset?
+                                       unfold iterate cycle infinite-range lazy-map lazy-filter
+                                       lazy-partition]]
+            [wisp.src.runtime :refer [str int inc dec even? odd? number? set? vals + =]]))
 
 
 (is (= (empty "foo") ""))
@@ -616,3 +618,38 @@
 (is (superset? [42] nil)          "superset? checks if all items from set2 are in set1")
 (is (superset? :of "foo")         "superset? works on equal sets")
 (is (not (superset? "baz" "bar")) "superset? works on different sets")
+
+
+(defn- binary* [n]    ; unfolder to binary form (reversed)
+  (if (> n 0) [(mod n 2) (int (/ n 2))]))
+(is (= (vec (unfold binary*  0)) []))
+(is (= (vec (unfold binary* 13)) [1 0 1 1]))      ; 1 + 4 + 8
+(is (= (vec (unfold binary* 42)) [0 1 0 1 0 1]))  ; 2 + 8 + 32
+
+(is (= (take 5 (iterate #(* % %) 2))
+       '(2 4 16 256 65536)))
+
+(is (= (take 10 (cycle [1 2 3]))
+       '(1 2 3 1 2 3 1 2 3 1)))
+
+(is (= (take 5 (infinite-range))
+       '(0 1 2 3 4)))
+(is (= (take 3 (infinite-range 2))
+       '(2 3 4)))
+(is (= (take 3 (infinite-range 2 -4))
+       '(2 -2 -6)))
+
+(is (= (take 5 (lazy-map inc (infinite-range)))
+       '(1 2 3 4 5)))
+
+(is (= (take 5 (lazy-filter odd? (infinite-range)))
+       '(1 3 5 7 9)))
+
+(is (= (take 3 (lazy-partition 2 (infinite-range)))
+       '((0 1) (2 3) (4 5))))
+(is (= (take 3 (lazy-partition 2 3 (infinite-range)))
+       '((0 1) (3 4) (6 7))))
+(is (= (take 3 (lazy-partition 2 3 (infinite-range 10) (range 7)))
+       '((0 1) (3 4) (6 10))))
+(is (= (take 3 (lazy-partition 2 3 (infinite-range 10) (range 6)))
+       '((0 1) (3 4))))

--- a/test/sequence.wisp
+++ b/test/sequence.wisp
@@ -8,7 +8,7 @@
                                        interleave nth lazy-seq set identity-set identity-set?
                                        contains? union difference intersection subset? superset?
                                        unfold iterate cycle infinite-range lazy-map lazy-filter
-                                       lazy-partition run! dorun doall]]
+                                       lazy-concat lazy-partition run! dorun doall]]
             [wisp.src.runtime :refer [str int inc dec even? odd? number? set? vals + =]]))
 
 
@@ -647,6 +647,9 @@
 (is (= (take 5 (lazy-filter odd? (infinite-range)))
        '(1 3 5 7 9)))
 
+(is (= (take 10 (lazy-concat (range 5) "abc" (infinite-range -1 -1)))
+       '(0 1 2 3 4 \a \b \c -1 -2)))
+
 (is (= (take 3 (lazy-partition 2 (infinite-range)))
        '((0 1) (2 3) (4 5))))
 (is (= (take 3 (lazy-partition 2 3 (infinite-range)))
@@ -664,6 +667,19 @@
 (is (= (*side-effects! #(take 0 (lazy-map % (range 3))))
        [[] nil])
     "take 0 won't evaluate the lazy sequence")
+
+(is (= (*side-effects! #(take 1 (lazy-concat (lazy-map % (range 5))
+                                             (lazy-map % "abc")
+                                             (lazy-map % (infinite-range -1 -1)))))
+       [[0] '(0)]))
+(is (= (*side-effects! #(take 6 (lazy-concat (lazy-map % (range 5))
+                                             (lazy-map % "abc")
+                                             (lazy-map % (infinite-range -1 -1)))))
+       [[0 1 2 3 4 :a] '(0 1)]))
+(is (= (*side-effects! #(take 9 (lazy-concat (lazy-map % (range 5))
+                                             (lazy-map % "abc")
+                                             (lazy-map % (infinite-range -1 -1)))))
+       [[0 1 2 3 4 :a :b :c -1] '(0 1)]))
 
 (is (= (*side-effects! #(run! % (range 3)))
        [[0 1 2] nil])

--- a/test/sequence.wisp
+++ b/test/sequence.wisp
@@ -631,6 +631,8 @@
 
 (is (= (take 10 (cycle [1 2 3]))
        '(1 2 3 1 2 3 1 2 3 1)))
+(is (= (take 10 (cycle []))
+       '()))
 
 (is (= (take 5 (infinite-range))
        '(0 1 2 3 4)))

--- a/test/sequence.wisp
+++ b/test/sequence.wisp
@@ -1,9 +1,9 @@
 (ns wisp.test.sequence
   (:require [wisp.test.util :refer [is thrown?]]
             [wisp.src.sequence :refer [cons conj into disj list list? empty seq vec vector
-                                       range empty? count first second third rest last
-                                       butlast take take-while drop drop-while repeat concat
-                                       mapcat reverse sort map mapv map-indexed filter
+                                       range empty? count first second third rest last butlast
+                                       take take-while drop drop-while repeatedly repeat concat
+                                       mapcat reverse sort map mapv map-indexed filter zipmap
                                        filterv reduce assoc dissoc every? some partition
                                        interleave nth lazy-seq set identity-set identity-set?
                                        contains? union difference intersection subset? superset?
@@ -360,6 +360,7 @@
        ["0a,foo" "1b,bar" "2c,baz"]))
 (is (= (map-indexed + #{\a \b \c}) '("0a" "1b" "2c")))
 
+(is (= (zipmap "abcde" (range 3)) {:a 0, :b 1, :c 2}))
 
 
 (is (= (filter even? nil) '()))
@@ -472,6 +473,8 @@
 (is (= (sort '("hello" "my" "dear" "frient"))
        '("dear" "frient" "hello" "my")))
 (is (= (sort (Set. [3 1 2 4])) '(1 2 3 4)))
+
+(is (= (repeatedly 5 #(* 6 7)) [42 42 42 42 42]))
 
 (is (= (repeat 4 7)  [7 7 7 7]))
 (is (= (repeat 0 7)  []))
@@ -586,6 +589,7 @@
 (is (= (nth [1 2 3 4] 2) 3))
 (is (= (nth [1 2 3 4] 0) 1))
 (is (= (nth (seq {:foo 1 :bar 2}) 1) [:bar 2]))
+(is (= (nth (Map. [[1 2] [3 4]]) 1) [3 4]))
 
 
 (is (contains? #{2 1 3} 3)           "contains? on sets checks for membership")

--- a/test/test.wisp
+++ b/test/test.wisp
@@ -7,4 +7,5 @@
             wisp.test.reader
             wisp.test.escodegen
             wisp.test.protocols
-            wisp.test.analyzer))
+            wisp.test.analyzer
+            wisp.test.macros))

--- a/test/test.wisp
+++ b/test/test.wisp
@@ -6,6 +6,5 @@
             wisp.test.string
             wisp.test.reader
             wisp.test.escodegen
-            ;wisp.test.protocols
-            ;wisp.test.analyzer
-            ))
+            wisp.test.protocols
+            wisp.test.analyzer))


### PR DESCRIPTION
* set functions
* improved lazy-seqs support (empty lazy-seqs, infinite sequences, not evaluating the whole sequence with `first` or `take`)
* improved self-hosting (recompiling with current version which allows limited use of current version marcos/etc… still requires it to compile with `node_modules` version first though)
* comprehensions and flow-control macros (threading, looping, conditional binding)
* [destructuring](https://github.com/Gozala/wisp/issues/4) (`let`, `fn`, `loop`)
* fixed [broken tests](https://github.com/Gozala/wisp/issues/166)
* added macros tests
* fixed a few discrepancies with Clojure (sequence equality test, `rem`/`mod`)